### PR TITLE
Add Java-based WebSocket server

### DIFF
--- a/server-java/README.md
+++ b/server-java/README.md
@@ -1,0 +1,27 @@
+# Project Livewire - Java Server
+
+This module implements the Project Livewire server in Java using Spring Boot with WebFlux and WebSocket support. It mirrors the behaviour of the Python server, forwarding client messages to Google Gemini and handling tool invocations.
+
+## Features
+- WebSocket endpoint at `/ws` on port `8081`
+- Sends a `{"ready": true}` message when a client connects
+- Streams text messages to Google Gemini and relays responses back to the client
+- Executes tool calls via HTTP cloud functions and forwards results to Gemini
+
+## Requirements
+- Java 17+
+- Maven
+- A valid Gemini API key (`GEMINI_API_KEY`)
+
+## Build and Run
+```bash
+mvn package
+java -jar target/server-java-1.0.0.jar
+```
+
+## Configuration
+Optional environment variables:
+- `GEMINI_MODEL` – Gemini model name (default `gemini-pro`)
+- `tool.weather.url` – Cloud function URL for the `get_weather` tool
+
+The server implements only text and tool call handling; support for images and audio can be extended as needed.

--- a/server-java/pom.xml
+++ b/server-java/pom.xml
@@ -1,0 +1,42 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.2.5</version>
+    <relativePath/>
+  </parent>
+
+  <groupId>com.google.livewire</groupId>
+  <artifactId>server-java</artifactId>
+  <version>1.0.0</version>
+  <properties>
+    <java.version>17</java.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-websocket</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/server-java/src/main/java/com/google/livewire/LivewireApplication.java
+++ b/server-java/src/main/java/com/google/livewire/LivewireApplication.java
@@ -1,0 +1,11 @@
+package com.google.livewire;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class LivewireApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(LivewireApplication.class, args);
+    }
+}

--- a/server-java/src/main/java/com/google/livewire/gemini/GeminiClient.java
+++ b/server-java/src/main/java/com/google/livewire/gemini/GeminiClient.java
@@ -1,0 +1,79 @@
+package com.google.livewire.gemini;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+/**
+ * Minimal client for Google Gemini REST API.
+ */
+@Component
+public class GeminiClient {
+    private final WebClient webClient;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final String model;
+
+    public GeminiClient(WebClient.Builder builder,
+                        @Value("${gemini.apiKey}") String apiKey,
+                        @Value("${gemini.model}") String model) {
+        this.model = model;
+        this.webClient = builder.baseUrl("https://generativelanguage.googleapis.com")
+                .defaultHeader("Authorization", "Bearer " + apiKey)
+                .build();
+    }
+
+    public Mono<JsonNode> generateContent(List<JsonNode> history, String text) {
+        ObjectNode request = mapper.createObjectNode();
+        ArrayNode contents = request.putArray("contents");
+        for (JsonNode node : history) {
+            contents.add(node);
+        }
+        ObjectNode user = mapper.createObjectNode();
+        user.put("role", "user");
+        ArrayNode parts = user.putArray("parts");
+        ObjectNode part = mapper.createObjectNode();
+        part.put("text", text);
+        parts.add(part);
+        contents.add(user);
+
+        return webClient.post()
+                .uri("/v1beta/models/" + model + ":generateContent")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(JsonNode.class);
+    }
+
+    public Mono<JsonNode> sendToolResponse(List<JsonNode> history, String name, JsonNode result) {
+        ObjectNode request = mapper.createObjectNode();
+        ArrayNode contents = request.putArray("contents");
+        for (JsonNode node : history) {
+            contents.add(node);
+        }
+        ObjectNode toolResponse = mapper.createObjectNode();
+        toolResponse.put("role", "tool");
+        ArrayNode parts = toolResponse.putArray("parts");
+        ObjectNode part = mapper.createObjectNode();
+        ObjectNode functionResult = mapper.createObjectNode();
+        functionResult.put("name", name);
+        functionResult.set("response", result);
+        part.set("functionResponse", functionResult);
+        parts.add(part);
+        contents.add(toolResponse);
+
+        return webClient.post()
+                .uri("/v1beta/models/" + model + ":generateContent")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(JsonNode.class);
+    }
+}

--- a/server-java/src/main/java/com/google/livewire/session/SessionManager.java
+++ b/server-java/src/main/java/com/google/livewire/session/SessionManager.java
@@ -1,0 +1,28 @@
+package com.google.livewire.session;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages SessionState objects for active WebSocket clients.
+ */
+@Component
+public class SessionManager {
+    private final Map<String, SessionState> sessions = new ConcurrentHashMap<>();
+
+    public SessionState createSession(String sessionId) {
+        SessionState state = new SessionState();
+        sessions.put(sessionId, state);
+        return state;
+    }
+
+    public SessionState getSession(String sessionId) {
+        return sessions.get(sessionId);
+    }
+
+    public void removeSession(String sessionId) {
+        sessions.remove(sessionId);
+    }
+}

--- a/server-java/src/main/java/com/google/livewire/session/SessionState.java
+++ b/server-java/src/main/java/com/google/livewire/session/SessionState.java
@@ -1,0 +1,35 @@
+package com.google.livewire.session;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Tracks the state of a client session.
+ */
+public class SessionState {
+    private final List<JsonNode> history = new ArrayList<>();
+    private boolean receivingResponse = false;
+    private boolean interrupted = false;
+
+    public List<JsonNode> getHistory() {
+        return history;
+    }
+
+    public boolean isReceivingResponse() {
+        return receivingResponse;
+    }
+
+    public void setReceivingResponse(boolean receivingResponse) {
+        this.receivingResponse = receivingResponse;
+    }
+
+    public boolean isInterrupted() {
+        return interrupted;
+    }
+
+    public void setInterrupted(boolean interrupted) {
+        this.interrupted = interrupted;
+    }
+}

--- a/server-java/src/main/java/com/google/livewire/tool/ToolHandler.java
+++ b/server-java/src/main/java/com/google/livewire/tool/ToolHandler.java
@@ -1,0 +1,55 @@
+package com.google.livewire.tool;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.util.Map;
+
+/**
+ * Executes external tools via HTTP cloud functions.
+ */
+@Component
+public class ToolHandler {
+    private final WebClient webClient;
+    private final Map<String, String> cloudFunctions;
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    public ToolHandler(WebClient.Builder builder,
+                       @Value("${tool.weather.url:}") String weatherUrl) {
+        this.webClient = builder.build();
+        this.cloudFunctions = Map.of("get_weather", weatherUrl);
+    }
+
+    public Mono<JsonNode> executeTool(String name, Map<String, String> params) {
+        String baseUrl = cloudFunctions.get(name);
+        if (baseUrl == null || baseUrl.isEmpty()) {
+            ObjectNode error = mapper.createObjectNode();
+            error.put("error", "Unknown tool: " + name);
+            return Mono.just(error);
+        }
+        URI uri = URI.create(baseUrl);
+        WebClient.RequestHeadersSpec<?> spec = webClient.get()
+            .uri(builder -> {
+                builder = builder.scheme(uri.getScheme())
+                        .host(uri.getHost())
+                        .path(uri.getPath());
+                params.forEach(builder::queryParam);
+                return builder.build();
+            })
+            .accept(MediaType.APPLICATION_JSON);
+        return spec.retrieve()
+            .bodyToMono(JsonNode.class)
+            .onErrorResume(e -> {
+                ObjectNode error = mapper.createObjectNode();
+                error.put("error", "Tool execution failed: " + e.getMessage());
+                return Mono.just(error);
+            });
+    }
+}

--- a/server-java/src/main/java/com/google/livewire/websocket/ChatWebSocketHandler.java
+++ b/server-java/src/main/java/com/google/livewire/websocket/ChatWebSocketHandler.java
@@ -1,0 +1,156 @@
+package com.google.livewire.websocket;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.livewire.gemini.GeminiClient;
+import com.google.livewire.session.SessionManager;
+import com.google.livewire.session.SessionState;
+import com.google.livewire.tool.ToolHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.WebSocketSession;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * WebSocket handler that forwards messages to Gemini and returns responses.
+ */
+@Component
+public class ChatWebSocketHandler implements WebSocketHandler {
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final GeminiClient geminiClient;
+    private final SessionManager sessionManager;
+    private final ToolHandler toolHandler;
+
+    public ChatWebSocketHandler(GeminiClient geminiClient,
+                                SessionManager sessionManager,
+                                ToolHandler toolHandler) {
+        this.geminiClient = geminiClient;
+        this.sessionManager = sessionManager;
+        this.toolHandler = toolHandler;
+    }
+
+    @Override
+    public Mono<Void> handle(WebSocketSession session) {
+        String id = session.getId();
+        SessionState state = sessionManager.createSession(id);
+
+        Mono<Void> ready = session.send(Mono.just(session.textMessage("{\"ready\":true}")));
+
+        Flux<WebSocketMessage> responses = session.receive()
+                .map(WebSocketMessage::getPayloadAsText)
+                .flatMap(payload -> handleClientMessage(payload, session, state));
+
+        return ready.thenMany(session.send(responses))
+                .doFinally(sig -> sessionManager.removeSession(id))
+                .then();
+    }
+
+    private Flux<WebSocketMessage> handleClientMessage(String payload, WebSocketSession session, SessionState state) {
+        try {
+            JsonNode root = mapper.readTree(payload);
+            String type = root.path("type").asText();
+            if ("text".equals(type)) {
+                String text = root.path("data").asText();
+                state.getHistory().add(buildUserMessage(text));
+                return geminiClient.generateContent(state.getHistory(), text)
+                        .flatMapMany(res -> processGeminiResponse(res, session, state));
+            }
+        } catch (Exception e) {
+            ObjectNode err = error("Invalid message", "Check format");
+            return Flux.just(session.textMessage(err.toString()));
+        }
+        return Flux.empty();
+    }
+
+    private Flux<WebSocketMessage> processGeminiResponse(JsonNode res, WebSocketSession session, SessionState state) {
+        JsonNode candidates = res.path("candidates");
+        if (candidates.isArray() && !candidates.isEmpty()) {
+            ArrayNode parts = (ArrayNode) candidates.get(0).path("content").path("parts");
+            return Flux.fromIterable(parts)
+                    .flatMap(part -> {
+                        if (part.has("functionCall")) {
+                            JsonNode func = part.get("functionCall");
+                            String name = func.path("name").asText();
+                            Map<String, String> params = new HashMap<>();
+                            func.path("args").fields().forEachRemaining(e -> params.put(e.getKey(), e.getValue().asText()));
+                            return toolHandler.executeTool(name, params)
+                                    .flatMapMany(result -> {
+                                        state.getHistory().add(buildFunctionResponse(name, result));
+                                        ObjectNode callMsg = mapper.createObjectNode();
+                                        callMsg.put("type", "function_call");
+                                        callMsg.set("data", func);
+                                        ObjectNode respMsg = mapper.createObjectNode();
+                                        respMsg.put("type", "function_response");
+                                        respMsg.set("data", result);
+                                        return Flux.concat(
+                                                Mono.just(session.textMessage(callMsg.toString())),
+                                                Mono.just(session.textMessage(respMsg.toString())),
+                                                geminiClient.sendToolResponse(state.getHistory(), name, result)
+                                                        .flatMapMany(r -> processGeminiResponse(r, session, state))
+                                        );
+                                    });
+                        } else if (part.has("text")) {
+                            String text = part.get("text").asText();
+                            state.getHistory().add(buildModelMessage(text));
+                            ObjectNode msg = mapper.createObjectNode();
+                            msg.put("type", "text");
+                            msg.put("data", text);
+                            return Flux.just(session.textMessage(msg.toString()));
+                        }
+                        return Flux.empty();
+                    });
+        }
+        return Flux.empty();
+    }
+
+    private ObjectNode buildUserMessage(String text) {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("role", "user");
+        ArrayNode parts = node.putArray("parts");
+        ObjectNode p = mapper.createObjectNode();
+        p.put("text", text);
+        parts.add(p);
+        return node;
+    }
+
+    private JsonNode buildModelMessage(String text) {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("role", "model");
+        ArrayNode parts = node.putArray("parts");
+        ObjectNode p = mapper.createObjectNode();
+        p.put("text", text);
+        parts.add(p);
+        return node;
+    }
+
+    private JsonNode buildFunctionResponse(String name, JsonNode response) {
+        ObjectNode node = mapper.createObjectNode();
+        node.put("role", "tool");
+        ArrayNode parts = node.putArray("parts");
+        ObjectNode p = mapper.createObjectNode();
+        ObjectNode fr = mapper.createObjectNode();
+        fr.put("name", name);
+        fr.set("response", response);
+        p.set("functionResponse", fr);
+        parts.add(p);
+        return node;
+    }
+
+    private ObjectNode error(String message, String action) {
+        ObjectNode data = mapper.createObjectNode();
+        data.put("message", message);
+        data.put("action", action);
+        data.put("error_type", "general");
+        ObjectNode wrapper = mapper.createObjectNode();
+        wrapper.put("type", "error");
+        wrapper.set("data", data);
+        return wrapper;
+    }
+}

--- a/server-java/src/main/java/com/google/livewire/websocket/WebSocketConfig.java
+++ b/server-java/src/main/java/com/google/livewire/websocket/WebSocketConfig.java
@@ -1,0 +1,27 @@
+package com.google.livewire.websocket;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter;
+
+import java.util.Map;
+
+@Configuration
+public class WebSocketConfig {
+    @Bean
+    public HandlerMapping handlerMapping(ChatWebSocketHandler handler) {
+        Map<String, WebSocketHandler> map = Map.of("/ws", handler);
+        SimpleUrlHandlerMapping mapping = new SimpleUrlHandlerMapping();
+        mapping.setOrder(-1);
+        mapping.setUrlMap(map);
+        return mapping;
+    }
+
+    @Bean
+    public WebSocketHandlerAdapter handlerAdapter() {
+        return new WebSocketHandlerAdapter();
+    }
+}

--- a/server-java/src/main/resources/application.properties
+++ b/server-java/src/main/resources/application.properties
@@ -1,0 +1,3 @@
+server.port=8081
+gemini.model=${GEMINI_MODEL:gemini-pro}
+gemini.apiKey=${GEMINI_API_KEY:}


### PR DESCRIPTION
## Summary
- Replace the prior Java WebSocket prototype with a Spring Boot WebFlux server mirroring the Python implementation
- Implement Gemini client, session manager, tool handler, and WebSocket flow to forward messages and tool calls
- Document build/run steps and configuration for the Java server

## Testing
- `mvn -q -f server-java/pom.xml package` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689c34b904508331adbb49a4b5fb247b